### PR TITLE
integration test to reproduce error with extra double quotes around Date parameter

### DIFF
--- a/lib/connection/statement.js
+++ b/lib/connection/statement.js
@@ -1124,7 +1124,11 @@ function buildBindsMap(bindsArray)
     {
       if (value !== null && !Util.isString(value))
       {
-        value = JSON.stringify(value);
+        if (value instanceof Date) {
+          value = value.toJSON();
+        } else {
+          value = JSON.stringify(value);
+        }
       }
     }
     else
@@ -1135,7 +1139,11 @@ function buildBindsMap(bindsArray)
         var value0 = bindsArray[rowIndex][index];
         if (value0 !== null && !Util.isString(value0))
         {
-          value0 = JSON.stringify(value0);
+          if (value0 instanceof Date) {
+            value0 = value0.toJSON();
+          } else {
+            value0 = JSON.stringify(value0);
+          }
         }
         value.push(value0);
       }

--- a/test/integration/testBind.js
+++ b/test/integration/testBind.js
@@ -599,7 +599,7 @@ describe('Test Bind Varible', function ()
       testingFunc(
         'timestamp_ntz',
         [new Date('Thu, 21 Jan 2016 06:32:44 -0800')],
-        [{'COLA': '2016-01-21T14:32:44.000Z'}],
+        [{'COLA': '2016-01-21 14:32:44.000'}],
         done
       );
     });

--- a/test/integration/testBind.js
+++ b/test/integration/testBind.js
@@ -594,6 +594,16 @@ describe('Test Bind Varible', function ()
       );
     });
 
+    it('testBindingTimestampNTZDate', function (done)
+    {
+      testingFunc(
+        'timestamp_ntz',
+        [new Date('Thu, 21 Jan 2016 06:32:44 -0800')],
+        [{'COLA': '2016-01-21T14:32:44.000Z'}],
+        done
+      );
+    });
+
     /*it('testBindingVariantSimple', function(done){
       var variant = {'a':1 , 'b':[1], 'c':{'a':1}};
       testingFunc(


### PR DESCRIPTION
Running test results in error:

```json
{
    "code": "100035",
    "data": {
        "age": 0,
        "errorCode": "100035",
        "internalError": false,
        "queryId": "01932646-02c8-a14c-0000-d2450037b742",
        "sqlState": "22007"
    },
    "message": "Timestamp '\"2016-01-21T14:32:44.000Z\"' is not recognized",
    "name": "OperationFailedError",
    "sqlState": "22007"
}
```